### PR TITLE
Fixing build error around relative paths

### DIFF
--- a/src/premake5.lua
+++ b/src/premake5.lua
@@ -9,7 +9,7 @@ project "node9"
     
     -- Initialize build
     -- Snapshot the kernel build / time
-    prebuildcommands {"src/styx/utils/ndate >src/include/kerndate.h"}
+    prebuildcommands {"styx/utils/ndate >include/kerndate.h"}
    
     -- primary kernel files --
     files {"main.c", "misc9.c", "styx/svcs/*.c",


### PR DESCRIPTION
This is a tiny fix that makes node9 build (as per instructions) on both Linux and Mac OS X. Not sure what has changed to required it so @jvburnes please take a look.