### PR TITLE
Adding a Dockerfile and starting publishing node9 runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.dockerignore

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,35 @@
+---
+name: Publish
+
+on:
+  push:
+    branches:
+      - "master"
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: "node9/runtime"
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            ${{env.IMAGE_NAME}}:${{github.sha}}
+            ${{env.IMAGE_NAME}}:0.0.${{github.run_number}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# Using Ubuntu LTS to avoid dependency churn
+FROM ubuntu:20.04 as build
+
+ENV PREMAKE_URL https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-linux.tar.gz
+
+# install dependencies
+RUN apt update
+RUN apt install -y gcc make autoconf automake git wget libtool
+RUN wget -O- $PREMAKE_URL | tar -C /bin -xzvf -
+
+# copy source
+COPY . /node9
+
+# build libuv
+WORKDIR /node9/libuv
+RUN sh autogen.sh && ./configure
+RUN make -j "$(getconf _NPROCESSORS_ONLN)"
+RUN rm .libs/lib*.so* # forcing static build
+
+# build luajit
+WORKDIR /node9/luajit
+RUN make -j "$(getconf _NPROCESSORS_ONLN)"
+RUN rm src/lib*.so* # forcing static build
+
+# build node9
+WORKDIR /node9
+RUN premake5 gmake
+# FIXME: there must be a way to tell premake to do this
+RUN sed -i_ -e 's#^ndate:#ndate: lib9#' -e 's#^libnode9:#libnode9: ndate#' -e 's#^node9:#node9: libnode9#' Makefile
+RUN make config=debug_linux -j "$(getconf _NPROCESSORS_ONLN)"
+
+# Finally, build the runtime environment
+FROM ubuntu:20.04
+
+COPY --from=build /node9/bin/* /bin/
+COPY --from=build /node9/lib/* /lib/
+COPY --from=build /node9/fs    /fs
+
+# define entry point
+WORKDIR /
+ENV LD_LIBRARY_PATH /node9/lib
+ENTRYPOINT ["/bin/node9"]


### PR DESCRIPTION
This PR is a rough cut of publishing Node9 into Dockerhub under the name node9/runtime. This will happen on every push into the master and will enable us to do things like:

```
$ docker run -it node9/runtime
node9 First Edition (20150610), build: 1609207059  main (pid=1)
Tue Dec 29 02:26:23 2020  node9/kernel: initializing terminal
Tue Dec 29 02:26:23 2020  node9/kernel: loading
Tue Dec 29 02:26:23 2020  node9/kernel: initializing namespace
Tue Dec 29 02:26:23 2020  node9/kernel: binding standard streams
Tue Dec 29 02:26:23 2020  node9/kernel: initializing host environment
Tue Dec 29 02:26:23 2020  node9/kernel: accepting requests
Tue Dec 29 02:26:23 2020  node9/kernel: starting luaspace ...
Tue Dec 29 02:26:23 2020  signals set
(/appl/sh): started
[the time on the console is Tue Dec 29 02:26:23 2020]
;
```

Or, more interestingly, things like:

```
$ docker run -it -v `pwd`/fs/appl:/fs/user node9/runtime
node9 First Edition (20150610), build: 1609207059  main (pid=1)
Tue Dec 29 02:26:23 2020  node9/kernel: initializing terminal
Tue Dec 29 02:26:23 2020  node9/kernel: loading
Tue Dec 29 02:26:23 2020  node9/kernel: initializing namespace
Tue Dec 29 02:26:23 2020  node9/kernel: binding standard streams
Tue Dec 29 02:26:23 2020  node9/kernel: initializing host environment
Tue Dec 29 02:26:23 2020  node9/kernel: accepting requests
Tue Dec 29 02:26:23 2020  node9/kernel: starting luaspace ...
Tue Dec 29 02:26:23 2020  signals set
(/appl/sh): started
[the time on the console is Tue Dec 29 02:26:23 2020]
; ls /user
--rw-r--r--         root         root         2193   Fri Dec 25 03:24:23 2020 apptest.lua
--rw-r--r--         root         root         2761   Fri Dec 25 03:24:23 2020 export.lua
--rw-r--r--         root         root         5910   Fri Dec 25 03:24:23 2020 listen.lua
--rw-r--r--         root         root          758   Fri Dec 25 03:24:22 2020 ls.lua
--rw-r--r--         root         root         8664   Fri Dec 25 03:24:22 2020 mount.lua
--rw-r--r--         root         root        10715   Sat Dec 26 02:08:46 2020 sh.lua
--rw-r--r--         root         root         6128   Fri Dec 25 03:24:22 2020 styxlisten.lua
--rw-r--r--         root         root        13668   Fri Dec 25 03:24:22 2020 syscall.lua
--rw-r--r--         root         root        23730   Fri Dec 25 03:24:22 2020 test.lua
--rw-r--r--         root         root          849   Fri Dec 25 03:24:22 2020 unmount.lua
```

Note that the usual `docker run -it node9/runtime -h` will work as expected as well and will print help message (and the same applies to all the other command line arguments that one would pass to node9 like `-t` for example).