### PR TITLE
Quick hack to account for async evens getting coalesced

### DIFF
--- a/src/styx/svcs/devcons.c
+++ b/src/styx/svcs/devcons.c
@@ -174,6 +174,7 @@ void readline(uv_async_t* key_wake)
 {
     char ch;
 
+keep:
     if(qread(kbdq, &ch, 1) == 0) {
          print("null char\n");
     }
@@ -215,6 +216,8 @@ void readline(uv_async_t* key_wake)
             kbd.x = 0;
         }
     }
+    if (qlen(kbdq))
+        goto keep;
 }
 
 void kbd_alloc(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf) {


### PR DESCRIPTION
While playing with node9 on both Mac OS X and Linux over the holidays, I kept running into a weird issue where if I cut-n-paste any text string into the console -- the console driver would get behind a random number of characters and not deliver strings back to the shell when I pressed enter. After some investigation it turns out that `libav` doesn't have a guarantee that X `uv_async_send` events would trigger exactly X wakeups of a handler. In fact, the handler may actually get woken up anywhere between 1 and X times (but at least one is guaranteed). This, of course, explains why I would see this 'console driver getting behind issue' and suggests a very simply fix along the lines of this PR.

We should probably turn it into a proper while loop if this gets to be the way we fix this issue, but I wanted to show the idea in the smallest diff possible first.

@jvburnes please let me know WDYT